### PR TITLE
List service requests immediately after creation

### DIFF
--- a/muni_portal/core/views/api/service_requests.py
+++ b/muni_portal/core/views/api/service_requests.py
@@ -132,7 +132,10 @@ class ServiceRequestListCreateView(ServiceRequestAPIView):
         ]
 
         service_request = ServiceRequest.objects.create(
-            user=request.user
+            user=request.user,
+            type=request_type,
+            request_date=request_date_iso,
+            status=ServiceRequest.CREATED,
         )
 
         async_task(create_service_request, service_request.id, form_fields, hook=handle_service_request_create)

--- a/muni_portal/core/views/api/service_requests.py
+++ b/muni_portal/core/views/api/service_requests.py
@@ -41,6 +41,10 @@ class ServiceRequestDetailView(ServiceRequestAPIView):
         object_id = local_object.collaborator_object_id
         serializer = ServiceRequestSerializer(local_object)
 
+        if not object_id:
+            # Object does not exist in collaborator yet, so return local object without updating from collaborator
+            return Response(serializer.data)
+
         client = Client(settings.COLLABORATOR_API_USERNAME, settings.COLLABORATOR_API_PASSWORD)
         client.authenticate()
         remote_object = client.get_task(object_id)
@@ -141,6 +145,16 @@ class ServiceRequestListCreateView(ServiceRequestAPIView):
             user=request.user,
             type=request_type,
             request_date=request_date,
+            user_name=user_name,
+            user_surname=user_surname,
+            user_mobile_number=user_mobile_number,
+            user_email_address=user_email_address,
+            street_name=street_name,
+            street_number=street_number,
+            suburb=suburb,
+            description=description,
+            coordinates=coordinates,
+            demarcation_code=demarcation_code
         )
 
         async_task(create_service_request, service_request.id, form_fields, hook=handle_service_request_create)

--- a/muni_portal/core/views/api/service_requests.py
+++ b/muni_portal/core/views/api/service_requests.py
@@ -75,15 +75,13 @@ class ServiceRequestListCreateView(ServiceRequestAPIView):
         if local_objects_with_ids:
             client = Client(settings.COLLABORATOR_API_USERNAME, settings.COLLABORATOR_API_PASSWORD)
             client.authenticate()
-        else:
-            return Response([])
 
-        for service_request in local_objects_with_ids:
-            local_object = self.get_object(service_request.pk, request.user)
-            serializer = ServiceRequestSerializer(local_object)
-            remote_object = client.get_task(local_object.collaborator_object_id)
-            serializer.update(local_object, remote_object)
-            response_list.append(serializer.data)
+            for service_request in local_objects_with_ids:
+                local_object = self.get_object(service_request.pk, request.user)
+                serializer = ServiceRequestSerializer(local_object)
+                remote_object = client.get_task(local_object.collaborator_object_id)
+                serializer.update(local_object, remote_object)
+                response_list.append(serializer.data)
 
         for local_object in local_objects_without_ids:
             serializer = ServiceRequestSerializer(local_object)


### PR DESCRIPTION
Trello: https://trello.com/c/GXz1lHKJ

## Changes
- Populate all fields on local object before queuing creation on collaborator
- Append list of local objects without `object_id` values to list view
- Return local object without updating from collaborator in detail view if it does not have an `object_id` value

## Notes
I opted to populate all the data instead of just the minimum required to list, so that if the user clicks to view the detail of the request, they can immediately see all the data they submitted. If instead they see a mostly blank request, they might think the data is missing or they captured it incorrectly.

## Submitted object in LIST:
![submitted](https://user-images.githubusercontent.com/7869992/114021800-60f00080-9871-11eb-92b0-cab64807cc75.png)

## Submitted object in detail:
![submitted-detail-populated](https://user-images.githubusercontent.com/7869992/114023275-f8a21e80-9872-11eb-861b-d384dab32120.png)

