### PR TITLE
Validate API POST fields before creating object

### DIFF
--- a/muni_portal/core/views/api/service_requests.py
+++ b/muni_portal/core/views/api/service_requests.py
@@ -132,7 +132,10 @@ class ServiceRequestListCreateView(ServiceRequestAPIView):
         ]
 
         service_request = ServiceRequest.objects.create(
-            user=request.user
+            user=request.user,
+            type=request_type,
+            request_date=request_date_iso,
+            status=ServiceRequest.CREATED,
         )
 
         async_task(create_service_request, service_request.id, form_fields, hook=handle_service_request_create)

--- a/muni_portal/core/views/api/service_requests.py
+++ b/muni_portal/core/views/api/service_requests.py
@@ -125,6 +125,15 @@ class ServiceRequestListCreateView(ServiceRequestAPIView):
         request_date_iso = request_date.isoformat()
         demarcation_code = "WC033"
 
+        serializer = ServiceRequestSerializer(
+            data={'user': request.user.pk,
+            'type': request_type, 'user_name': user_name, 'user_surname': user_surname, 'user_mobile_number': user_mobile_number,
+                'user_email_address': user_email_address, 'street_name': street_name, 'street_number': street_number, 'suburb': suburb,
+                'description': description, 'coordinates': coordinates, 'request_date': request_date, 'demarcartion_code': demarcation_code
+            }
+        )
+        serializer.is_valid(raise_exception=True)
+
         # Translate POST parameters received into Collaborator Web API form fields
         form_fields: List[FormField] = [
             {"FieldID": "F1", "FieldValue": request_type},

--- a/muni_portal/core/views/api/service_requests.py
+++ b/muni_portal/core/views/api/service_requests.py
@@ -41,6 +41,10 @@ class ServiceRequestDetailView(ServiceRequestAPIView):
         object_id = local_object.collaborator_object_id
         serializer = ServiceRequestSerializer(local_object)
 
+        if not object_id:
+            # Object does not exist in collaborator yet, so return local object without updating from collaborator
+            return Response(serializer.data)
+
         client = Client(settings.COLLABORATOR_API_USERNAME, settings.COLLABORATOR_API_PASSWORD)
         client.authenticate()
         remote_object = client.get_task(object_id)
@@ -141,6 +145,16 @@ class ServiceRequestListCreateView(ServiceRequestAPIView):
             user=request.user,
             type=request_type,
             request_date=request_date,
+            user_name=user_name,
+            user_surname=user_surname,
+            user_mobile_number=user_mobile_number,
+            user_email_address=user_email_address,
+            street_name=street_name,
+            street_number=street_number,
+            suburb=suburb,
+            description=description,
+            coordinates=coordinates,
+            demarcation_code=demarcation_code
         )
 
         async_task(create_service_request, service_request.id, form_fields, hook=handle_service_request_create)

--- a/muni_portal/core/views/api/service_requests.py
+++ b/muni_portal/core/views/api/service_requests.py
@@ -17,7 +17,6 @@ from django_q.tasks import async_task
 
 
 class ServiceRequestAPIView(views.APIView):
-
     @staticmethod
     def get_object(pk: int, user: User) -> ServiceRequest:
         try:
@@ -45,7 +44,9 @@ class ServiceRequestDetailView(ServiceRequestAPIView):
             # Object does not exist in collaborator yet, so return local object without updating from collaborator
             return Response(serializer.data)
 
-        client = Client(settings.COLLABORATOR_API_USERNAME, settings.COLLABORATOR_API_PASSWORD)
+        client = Client(
+            settings.COLLABORATOR_API_USERNAME, settings.COLLABORATOR_API_PASSWORD
+        )
         client.authenticate()
         remote_object = client.get_task(object_id)
         serializer.update(local_object, remote_object)
@@ -53,13 +54,18 @@ class ServiceRequestDetailView(ServiceRequestAPIView):
 
 
 class ServiceRequestListCreateView(ServiceRequestAPIView):
-
     permission_classes = [IsAuthenticated]
 
     CREATE_REQUIRED_FIELDS = (
-            "type", "user_name", "user_surname", "user_mobile_number",
-            "street_name", "street_number", "suburb", "description"
-        )
+        "type",
+        "user_name",
+        "user_surname",
+        "user_mobile_number",
+        "street_name",
+        "street_number",
+        "suburb",
+        "description",
+    )
 
     def get(self, request) -> Response:
         """
@@ -69,11 +75,17 @@ class ServiceRequestListCreateView(ServiceRequestAPIView):
         of each object from Collaborator Web API and returning it as a list.
         """
         response_list = []
-        local_objects_with_ids = ServiceRequest.objects.filter(user=request.user, collaborator_object_id__isnull=False)
-        local_objects_without_ids = ServiceRequest.objects.filter(user=request.user, collaborator_object_id__isnull=True)
+        local_objects_with_ids = ServiceRequest.objects.filter(
+            user=request.user, collaborator_object_id__isnull=False
+        )
+        local_objects_without_ids = ServiceRequest.objects.filter(
+            user=request.user, collaborator_object_id__isnull=True
+        )
 
         if local_objects_with_ids:
-            client = Client(settings.COLLABORATOR_API_USERNAME, settings.COLLABORATOR_API_PASSWORD)
+            client = Client(
+                settings.COLLABORATOR_API_USERNAME, settings.COLLABORATOR_API_PASSWORD
+            )
             client.authenticate()
         else:
             return Response([])
@@ -126,10 +138,20 @@ class ServiceRequestListCreateView(ServiceRequestAPIView):
         demarcation_code = "WC033"
 
         serializer = ServiceRequestSerializer(
-            data={'user': request.user.pk,
-            'type': request_type, 'user_name': user_name, 'user_surname': user_surname, 'user_mobile_number': user_mobile_number,
-                'user_email_address': user_email_address, 'street_name': street_name, 'street_number': street_number, 'suburb': suburb,
-                'description': description, 'coordinates': coordinates, 'request_date': request_date, 'demarcartion_code': demarcation_code
+            data={
+                "user": request.user.pk,
+                "type": request_type,
+                "user_name": user_name,
+                "user_surname": user_surname,
+                "user_mobile_number": user_mobile_number,
+                "user_email_address": user_email_address,
+                "street_name": street_name,
+                "street_number": street_number,
+                "suburb": suburb,
+                "description": description,
+                "coordinates": coordinates,
+                "request_date": request_date,
+                "demarcartion_code": demarcation_code,
             }
         )
         serializer.is_valid(raise_exception=True)
@@ -147,7 +169,7 @@ class ServiceRequestListCreateView(ServiceRequestAPIView):
             {"FieldID": "F10", "FieldValue": description},
             {"FieldID": "F11", "FieldValue": coordinates},
             {"FieldID": "F12", "FieldValue": request_date_iso},
-            {"FieldID": "F20", "FieldValue": demarcation_code}
+            {"FieldID": "F20", "FieldValue": demarcation_code},
         ]
 
         service_request = ServiceRequest.objects.create(
@@ -163,9 +185,14 @@ class ServiceRequestListCreateView(ServiceRequestAPIView):
             suburb=suburb,
             description=description,
             coordinates=coordinates,
-            demarcation_code=demarcation_code
+            demarcation_code=demarcation_code,
         )
 
-        async_task(create_service_request, service_request.id, form_fields, hook=handle_service_request_create)
+        async_task(
+            create_service_request,
+            service_request.id,
+            form_fields,
+            hook=handle_service_request_create,
+        )
 
         return Response(status=201)


### PR DESCRIPTION
Trello: https://trello.com/c/mykphwKZ/241-enforce-model-constraints-on-api-views

⚠️ This PR is branched off from #75 so that must be merged before this to get a cleaner diff. 

Utilises Serializer from Django-Rest-Framework to do basic model validation

Returns response like this if there are any errors:
```
{"user_email_address":["Enter a valid email address."],"description":["Ensure this field has no more than 1024 characters."]}
```